### PR TITLE
Disable pagination to non-existent pages

### DIFF
--- a/components/book-pagination.tsx
+++ b/components/book-pagination.tsx
@@ -28,7 +28,7 @@ export function BookPagination({
       <PaginationContent>
         <PaginationItem>
           <PaginationPrevious
-            href={createPageURL(currentPage - 1)}
+            href={createPageURL(currentPage > 1 ? currentPage - 1 : 1)}
             aria-disabled={currentPage <= 1}
           />
         </PaginationItem>
@@ -59,7 +59,7 @@ export function BookPagination({
         })}
         <PaginationItem>
           <PaginationNext
-            href={createPageURL(currentPage + 1)}
+            href={createPageURL(currentPage < totalPages ? currentPage + 1 : totalPages)}
             aria-disabled={currentPage >= totalPages}
           />
         </PaginationItem>


### PR DESCRIPTION
It might also make sense to "disable" those links.
I.e. adding `tabIndex={-1} className="pointer-events-none"`