### PR TITLE
Fix back button

### DIFF
--- a/app/[id]/back.tsx
+++ b/app/[id]/back.tsx
@@ -5,9 +5,17 @@ import { useRouter } from 'next/navigation';
 export default function BackButton() {
   let router = useRouter();
 
+  function handleClick() {
+    if (typeof window !== "undefined" && window.history.length > 1) {
+      router.back();
+    } else {
+      router.push("/");
+    }
+  }
+
   return (
     <button
-      onClick={() => router.back()}
+      onClick={handleClick}
       className="p-3 mb-8 mr-auto rounded hover:bg-gray-100"
     >
       ← Back to all books


### PR DESCRIPTION
When you access the `/[id]` route by directly visiting the URL (such as `https://next-books-search.vercel.app/52304`), the "Back to all books" won't take you back to the grid of books. This is because it calls `router.back()` when there is no previous history to go back to.

This PR fixes the issue by redirecting to the home page `"/"` if the browser history has no previous entries.

Note that this is not a perfect fix, and there are still scenarios where the button is broken. After clicking a link like https://next-books-search.vercel.app/52304, the button will send you back to the page you came from (in this case Github), instead of the page with all books.