### PR TITLE
Add db:migrate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ This is a book inventory app built with Next.js, Drizzle, and PostgreSQL. The da
 
 ## Database Setup
 
-This is currently using a Postgres extension called `unaccent` to remove accents from the book titles. To install this extension, run the following command on your database:
+This is currently using a Postgres extension called `unaccent` to remove accents from the book titles. This also uses the pgvector extension to use Postgres as a vector store. To install these extensions, run the following command on your database:
 
 ```sql
 CREATE EXTENSION IF NOT EXISTS unaccent;
+CREATE EXTENSION IF NOT EXISTS vector;
 ```
 
 ## Deploy on Vercel

--- a/lib/db/migrate.ts
+++ b/lib/db/migrate.ts
@@ -1,0 +1,14 @@
+import dotenv from 'dotenv';
+import path from 'path';
+import { migrate } from 'drizzle-orm/neon-http/migrator';
+
+dotenv.config();
+
+import { db } from './drizzle';
+
+async function main() {
+  await migrate(db, { migrationsFolder: path.join(__dirname, './migrations') });
+  console.log(`Migrations complete`);
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "next start",
     "db:generate": "drizzle-kit generate",
     "db:studio": "drizzle-kit studio",
+    "db:migrate": "tsx lib/db/migrate.ts",
     "db:seed-authors": "tsx lib/db/seed-authors.ts",
     "db:seed-books": "tsx lib/db/seed-books.ts",
     "db:seed-thumbhash": "tsx lib/db/seed-thumbhash.ts",


### PR DESCRIPTION
Adds a new command to run database migrations created via `db:generate`. 

```
pnpm run db:migrate
```

**Notes**
* This assumes using Neon's http driver. If we need to support others, we can make a change.
* This also documents the use of pgvector in the README
* To insert books successfully, I had to remove the `notNull()` constraint on the book table's `title_tsv` column.